### PR TITLE
sns-testing: validate IC network setup and target canister before running the basic scenario

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12592,6 +12592,7 @@ dependencies = [
  "ic-sns-cli",
  "ic-sns-governance-api",
  "ic-sns-swap",
+ "ic-sns-wasm",
  "icp-ledger",
  "k256 0.13.4",
  "pocket-ic",
@@ -12601,6 +12602,7 @@ dependencies = [
  "serde",
  "slog",
  "tempfile",
+ "thiserror 2.0.11",
  "tokio",
  "url",
 ]

--- a/rs/nervous_system/agent/src/nns/sns_wasm.rs
+++ b/rs/nervous_system/agent/src/nns/sns_wasm.rs
@@ -9,7 +9,9 @@ use ic_sns_wasm::pb::v1::{
     GetDeployedSnsByProposalIdRequest, GetDeployedSnsByProposalIdResponse, GetWasmRequest,
     GetWasmResponse, ListDeployedSnsesRequest, ListUpgradeStepsRequest, ListUpgradeStepsResponse,
 };
-use ic_sns_wasm::pb::v1::{GetNextSnsVersionRequest, SnsVersion};
+use ic_sns_wasm::pb::v1::{
+    GetNextSnsVersionRequest, GetSnsSubnetIdsRequest, GetSnsSubnetIdsResponse, SnsVersion,
+};
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 use tokio::fs::File;
@@ -68,6 +70,14 @@ pub async fn list_deployed_snses<C: CallCanisters>(agent: &C) -> Result<Vec<Sns>
         .filter_map(|deployed_sns| crate::sns::Sns::try_from(deployed_sns).ok())
         .collect::<Vec<_>>();
     Ok(snses)
+}
+
+pub async fn get_sns_subnet_ids<C: CallCanisters>(
+    agent: &C,
+) -> Result<GetSnsSubnetIdsResponse, C::Error> {
+    agent
+        .call(SNS_WASM_CANISTER_ID, GetSnsSubnetIdsRequest {})
+        .await
 }
 
 pub async fn get_git_version_for_sns_hash(

--- a/rs/nervous_system/agent/src/nns/sns_wasm/requests.rs
+++ b/rs/nervous_system/agent/src/nns/sns_wasm/requests.rs
@@ -3,11 +3,11 @@ use ic_sns_wasm::pb::v1::{
     AddWasmRequest, AddWasmResponse, DeployNewSnsRequest, DeployNewSnsResponse,
     GetDeployedSnsByProposalIdRequest, GetDeployedSnsByProposalIdResponse,
     GetNextSnsVersionRequest, GetNextSnsVersionResponse, GetProposalIdThatAddedWasmRequest,
-    GetProposalIdThatAddedWasmResponse, GetWasmMetadataRequest, GetWasmMetadataResponse,
-    GetWasmRequest, GetWasmResponse, InsertUpgradePathEntriesRequest,
-    InsertUpgradePathEntriesResponse, ListDeployedSnsesRequest, ListDeployedSnsesResponse,
-    ListUpgradeStepsRequest, ListUpgradeStepsResponse, UpdateSnsSubnetListRequest,
-    UpdateSnsSubnetListResponse,
+    GetProposalIdThatAddedWasmResponse, GetSnsSubnetIdsRequest, GetSnsSubnetIdsResponse,
+    GetWasmMetadataRequest, GetWasmMetadataResponse, GetWasmRequest, GetWasmResponse,
+    InsertUpgradePathEntriesRequest, InsertUpgradePathEntriesResponse, ListDeployedSnsesRequest,
+    ListDeployedSnsesResponse, ListUpgradeStepsRequest, ListUpgradeStepsResponse,
+    UpdateSnsSubnetListRequest, UpdateSnsSubnetListResponse,
 };
 
 impl Request for ListDeployedSnsesRequest {
@@ -166,7 +166,6 @@ impl Request for InsertUpgradePathEntriesRequest {
     fn payload(&self) -> Result<Vec<u8>, candid::Error> {
         candid::encode_one(self)
     }
-
     type Response = InsertUpgradePathEntriesResponse;
 }
 
@@ -184,4 +183,20 @@ impl Request for UpdateSnsSubnetListRequest {
     }
 
     type Response = UpdateSnsSubnetListResponse;
+}
+
+impl Request for GetSnsSubnetIdsRequest {
+    fn method(&self) -> &'static str {
+        "get_sns_subnet_ids"
+    }
+
+    fn update(&self) -> bool {
+        false
+    }
+
+    fn payload(&self) -> Result<Vec<u8>, candid::Error> {
+        candid::encode_one(self)
+    }
+
+    type Response = GetSnsSubnetIdsResponse;
 }

--- a/rs/sns/testing/BUILD.bazel
+++ b/rs/sns/testing/BUILD.bazel
@@ -16,6 +16,7 @@ DEPENDENCIES = [
     "//rs/nns/common",
     "//rs/nns/constants",
     "//rs/nns/governance/api",
+    "//rs/nns/sns-wasm",
     "//rs/nns/test_utils",
     "//rs/registry/transport",
     "//rs/rust_canisters/canister_test",
@@ -36,6 +37,7 @@ DEPENDENCIES = [
     "@crate_index//:reqwest",
     "@crate_index//:slog",
     "@crate_index//:tempfile",
+    "@crate_index//:thiserror",
     "@crate_index//:tokio",
     "@crate_index//:url",
 ]

--- a/rs/sns/testing/Cargo.toml
+++ b/rs/sns/testing/Cargo.toml
@@ -43,6 +43,7 @@ ic-registry-transport = { path = "../../registry/transport" }
 ic-sns-cli = { path = "../cli" }
 ic-sns-governance-api = { path = "../../sns/governance/api" }
 ic-sns-swap = { path = "../swap" }
+ic-sns-wasm = { path = "../../nns/sns-wasm" }
 icp-ledger = { path = "../../ledger_suite/icp" }
 k256 = { workspace = true }
 pocket-ic = { path = "../../../packages/pocket-ic" }
@@ -52,5 +53,6 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 slog ={ workspace = true }
 tempfile = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }

--- a/rs/sns/testing/src/utils.rs
+++ b/rs/sns/testing/src/utils.rs
@@ -1,20 +1,41 @@
-use anyhow::anyhow;
-use anyhow::Context;
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 use dfx_core::identity::identity_manager::InitializeIdentity;
 use dfx_core::identity::IdentityManager;
+use futures::future::join_all;
 use ic_agent::{
     agent::route_provider::RoundRobinRouteProvider, identity::Secp256k1Identity, Agent,
 };
+use ic_base_types::CanisterId;
 use ic_base_types::PrincipalId;
 use ic_nervous_system_agent::nns::governance::list_neurons;
+use ic_nervous_system_agent::nns::sns_wasm::get_sns_subnet_ids;
+use ic_nervous_system_agent::nns::sns_wasm::list_upgrade_steps;
 use ic_nervous_system_agent::CallCanisters;
 use ic_nervous_system_common_test_keys::TEST_NEURON_1_ID;
 use ic_nns_common::pb::v1::NeuronId;
+use ic_nns_constants::{
+    canister_id_to_nns_canister_name, CYCLES_LEDGER_CANISTER_ID, CYCLES_MINTING_CANISTER_ID,
+    GOVERNANCE_CANISTER_ID, LEDGER_CANISTER_ID, LEDGER_INDEX_CANISTER_ID, LIFELINE_CANISTER_ID,
+    REGISTRY_CANISTER_ID, ROOT_CANISTER_ID, SNS_WASM_CANISTER_ID,
+};
 use ic_nns_governance_api::pb::v1::{ListNeurons, Neuron};
+use ic_sns_wasm::pb::v1::ListUpgradeStepsRequest;
 use k256::SecretKey;
 use reqwest::Client;
+use thiserror::Error;
+
+pub const ALL_NNS_CANISTER_IDS: [&CanisterId; 9] = [
+    &GOVERNANCE_CANISTER_ID,
+    &LEDGER_CANISTER_ID,
+    &ROOT_CANISTER_ID,
+    &LIFELINE_CANISTER_ID,
+    &SNS_WASM_CANISTER_ID,
+    &REGISTRY_CANISTER_ID,
+    &CYCLES_MINTING_CANISTER_ID,
+    &LEDGER_INDEX_CANISTER_ID,
+    &CYCLES_LEDGER_CANISTER_ID,
+];
 
 pub const NNS_NEURON_ID: NeuronId = NeuronId {
     id: TEST_NEURON_1_ID,
@@ -71,4 +92,140 @@ pub fn get_identity_principal(identity_name: &str) -> Result<PrincipalId> {
         .get_selected_identity_principal()
         .ok_or_else(|| anyhow!("Failed to get principal for identity `{}`", identity_name))
         .map(PrincipalId::from)
+}
+
+pub async fn check_canister_installed<C: CallCanisters>(
+    agent: &C,
+    canister_id: &CanisterId,
+) -> bool {
+    agent
+        .canister_info(*canister_id)
+        .await
+        .map(|canister_info| canister_info.module_hash.is_some())
+        .unwrap_or_default()
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum SnsTestingNetworkValidationError {
+    #[error("NNS canister '{0}' is missing")]
+    MissingNnsCanister(String),
+    #[error("Network does not have any SNS subnets")]
+    MissingSnsSubnets,
+    #[error("Failed to get SNS subnet IDs: {0}")]
+    FailedToGetSnsSubnetIds(String),
+    #[error("SNS WASM doesn't have any upgrade steps")]
+    MissingSnsWasmUpgradeSteps,
+    #[error("Failed to get SNS WASM upgrade steps: {0}")]
+    FailedToGetSnsWasmUpgradeSteps(String),
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum SnsTestingCanisterValidationError {
+    #[error("Canister {0} is not installed")]
+    CanisterNotInstalled(CanisterId),
+    #[error("Canister {0} is not controlled by the NNS Root canister")]
+    CanisterNotControlledByNnsRoot(CanisterId),
+    #[error("Failed to get canister '{0}' info: {1}")]
+    FailedToGetCanisterInfo(CanisterId, String),
+}
+
+// Function that validates the provided IC network setup.
+// It ensures that all required NNS canisters exist and are installed
+// and the network has at least one SNS subnet.
+pub async fn validate_network<C: CallCanisters>(
+    agent: &C,
+) -> Vec<SnsTestingNetworkValidationError> {
+    let canisters_installed = join_all(
+        ALL_NNS_CANISTER_IDS
+            .iter()
+            .map(|canister_id| async { check_canister_installed(agent, canister_id).await }),
+    )
+    .await;
+    let (_, validation_errors): (Vec<_>, Vec<_>) = ALL_NNS_CANISTER_IDS
+        .iter()
+        .zip(canisters_installed)
+        .map(|(canister_id, installed)| {
+            if !installed {
+                Err(SnsTestingNetworkValidationError::MissingNnsCanister(
+                    canister_id_to_nns_canister_name(**canister_id),
+                ))
+            } else {
+                Ok(())
+            }
+        })
+        .partition(Result::is_ok);
+    let mut validation_errors: Vec<SnsTestingNetworkValidationError> = validation_errors
+        .into_iter()
+        .map(Result::unwrap_err)
+        .collect();
+    match get_sns_subnet_ids(agent).await {
+        Ok(response) => {
+            if response.sns_subnet_ids.is_empty() {
+                validation_errors.push(SnsTestingNetworkValidationError::MissingSnsSubnets);
+            }
+        }
+        Err(err) => {
+            validation_errors.push(SnsTestingNetworkValidationError::FailedToGetSnsSubnetIds(
+                err.to_string(),
+            ));
+        }
+    }
+
+    match list_upgrade_steps(
+        agent,
+        ListUpgradeStepsRequest {
+            starting_at: None,
+            sns_governance_canister_id: None,
+            limit: 0,
+        },
+    )
+    .await
+    {
+        Ok(response) => {
+            if response.steps.is_empty() {
+                validation_errors
+                    .push(SnsTestingNetworkValidationError::MissingSnsWasmUpgradeSteps);
+            }
+        }
+        Err(err) => {
+            validation_errors.push(
+                SnsTestingNetworkValidationError::FailedToGetSnsWasmUpgradeSteps(err.to_string()),
+            );
+        }
+    }
+    validation_errors
+}
+
+// Function that validates that provided canister is suitable to be used in SNS.
+// It ensures that canister exists, is installed and controlled by the NNS Root canister.
+pub async fn validate_target_canister<C: CallCanisters>(
+    agent: &C,
+    canister_id: CanisterId,
+) -> Vec<SnsTestingCanisterValidationError> {
+    let mut validation_errors = vec![];
+    // let canister_info = agent.canister_info(canister_id).await;
+    match agent.canister_info(canister_id).await {
+        Ok(canister_info) => {
+            if canister_info.module_hash.is_none() {
+                validation_errors.push(SnsTestingCanisterValidationError::CanisterNotInstalled(
+                    canister_id,
+                ));
+            }
+            if !canister_info
+                .controllers
+                .contains(&ROOT_CANISTER_ID.get().into())
+            {
+                validation_errors.push(
+                    SnsTestingCanisterValidationError::CanisterNotControlledByNnsRoot(canister_id),
+                );
+            }
+        }
+        Err(err) => {
+            validation_errors.push(SnsTestingCanisterValidationError::FailedToGetCanisterInfo(
+                canister_id,
+                err.to_string(),
+            ));
+        }
+    }
+    validation_errors
 }

--- a/rs/sns/testing/tests/sns_testing_ci.rs
+++ b/rs/sns/testing/tests/sns_testing_ci.rs
@@ -1,17 +1,26 @@
 use candid::{Decode, Encode, Principal};
-use ic_base_types::PrincipalId;
-use ic_nervous_system_integration_tests::pocket_ic_helpers::load_registry_mutations;
+use canister_test::Wasm;
+use ic_base_types::{CanisterId, PrincipalId};
+use ic_nervous_system_integration_tests::pocket_ic_helpers::{
+    install_canister_on_subnet, load_registry_mutations, NnsInstaller, STARTING_CYCLES_PER_CANISTER,
+};
+use ic_nns_constants::{LEDGER_INDEX_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_sns_testing::nns_dapp::bootstrap_nns;
 use ic_sns_testing::sns::{
     create_sns_pocket_ic, install_test_canister, upgrade_sns_controlled_test_canister_pocket_ic,
     TestCanisterInitArgs,
 };
+use ic_sns_testing::utils::{
+    validate_network, validate_target_canister, SnsTestingCanisterValidationError,
+    SnsTestingNetworkValidationError,
+};
 use icp_ledger::Tokens;
+use pocket_ic::management_canister::CanisterSettings;
 use pocket_ic::PocketIcBuilder;
 use tempfile::TempDir;
 
 #[tokio::test]
-async fn test_sns_testing_pocket_ic() {
+async fn test_sns_testing_basic_scenario() {
     let state_dir = TempDir::new().unwrap();
     let state_dir = state_dir.path().to_path_buf();
 
@@ -38,6 +47,7 @@ async fn test_sns_testing_pocket_ic() {
         vec![dev_participant_id],
     )
     .await;
+    assert!(validate_network(&pocket_ic).await.is_empty());
     let greeting = "Hello there".to_string();
     let test_canister_id = install_test_canister(
         &pocket_ic,
@@ -46,6 +56,9 @@ async fn test_sns_testing_pocket_ic() {
         },
     )
     .await;
+    assert!(validate_target_canister(&pocket_ic, test_canister_id)
+        .await
+        .is_empty());
     let test_call_arg = "General Kenobi".to_string();
     let test_canister_response = pocket_ic
         .query_call(
@@ -91,4 +104,144 @@ async fn test_sns_testing_pocket_ic() {
         Decode!(&test_canister_response, String).expect("Failed to decode test canister response"),
         format!("{}, {}!", new_greeting, test_call_arg),
     );
+}
+
+#[tokio::test]
+pub async fn test_missing_nns_canisters() {
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build_async()
+        .await;
+    bootstrap_nns(&pocket_ic, vec![], vec![], vec![]).await;
+    pocket_ic
+        .stop_canister(
+            LEDGER_INDEX_CANISTER_ID.get().into(),
+            Some(ROOT_CANISTER_ID.get().into()),
+        )
+        .await
+        .unwrap();
+    pocket_ic
+        .delete_canister(
+            LEDGER_INDEX_CANISTER_ID.get().into(),
+            Some(ROOT_CANISTER_ID.get().into()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        validate_network(&pocket_ic).await,
+        vec![SnsTestingNetworkValidationError::MissingNnsCanister(
+            "ledger-index".to_string(),
+        )]
+    )
+}
+
+#[tokio::test]
+pub async fn test_missing_sns_wasm_upgrade_steps() {
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build_async()
+        .await;
+    let mut nns_installer = NnsInstaller::default();
+    nns_installer.with_current_nns_canister_versions();
+    nns_installer.with_test_governance_canister();
+    nns_installer.with_cycles_minting_canister();
+    nns_installer.with_cycles_ledger();
+    nns_installer.with_index_canister();
+    nns_installer.with_custom_registry_mutations(vec![]);
+    nns_installer.with_ledger_balances(vec![]);
+    nns_installer.with_neurons_fund_hotkeys(vec![]);
+    nns_installer.install(&pocket_ic).await;
+    assert_eq!(
+        validate_network(&pocket_ic).await,
+        vec![SnsTestingNetworkValidationError::MissingSnsWasmUpgradeSteps,]
+    )
+}
+
+#[tokio::test]
+pub async fn test_non_installed_target_canister() {
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build_async()
+        .await;
+    let topology = pocket_ic.topology().await;
+    let application_subnet_ids = topology.get_app_subnets();
+    let application_subnet_id = application_subnet_ids[0];
+    let canister_id = pocket_ic
+        .create_canister_on_subnet(
+            None,
+            Some(CanisterSettings {
+                controllers: Some(vec![ROOT_CANISTER_ID.get().into()]),
+                ..Default::default()
+            }),
+            application_subnet_id,
+        )
+        .await;
+    pocket_ic
+        .add_cycles(canister_id, STARTING_CYCLES_PER_CANISTER)
+        .await;
+    let canister_id = CanisterId::unchecked_from_principal(canister_id.into());
+    assert_eq!(
+        validate_target_canister(&pocket_ic, canister_id).await,
+        vec![SnsTestingCanisterValidationError::CanisterNotInstalled(
+            canister_id
+        )],
+    )
+}
+
+#[tokio::test]
+pub async fn test_nonexisting_target_canister() {
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build_async()
+        .await;
+    let canister_id = CanisterId::unchecked_from_principal(PrincipalId::new_user_test_id(1000));
+    assert!(match validate_target_canister(&pocket_ic, canister_id)
+        .await
+        .as_slice()
+    {
+        [SnsTestingCanisterValidationError::FailedToGetCanisterInfo(err_canister_id, _)] => {
+            err_canister_id == &canister_id
+        }
+        _ => false,
+    })
+}
+
+#[tokio::test]
+pub async fn test_target_canister_not_controlled_by_nns_root() {
+    let pocket_ic = PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_sns_subnet()
+        .with_ii_subnet()
+        .with_application_subnet()
+        .build_async()
+        .await;
+    let topology = pocket_ic.topology().await;
+    let application_subnet_ids = topology.get_app_subnets();
+    let application_subnet_id = application_subnet_ids[0];
+    let test_canister_wasm = Wasm::from_bytes([0, 0x61, 0x73, 0x6D, 1, 0, 0, 0]);
+    let canister_controller = PrincipalId::new_user_test_id(1000);
+    let canister_id = install_canister_on_subnet(
+        &pocket_ic,
+        application_subnet_id,
+        vec![],
+        Some(test_canister_wasm),
+        vec![canister_controller],
+    )
+    .await;
+    assert_eq!(
+        validate_target_canister(&pocket_ic, canister_id).await,
+        vec![SnsTestingCanisterValidationError::CanisterNotControlledByNnsRoot(canister_id)]
+    )
 }


### PR DESCRIPTION
If the network setup is invalid or the target canister doesn't have the
correct state (e.g. doesn't have the NNS Root canister as a controller),
the scenario may fail during the execution throwing potentially
confusing errors from NNS/SNS canisters and leaving the SNS in 'failed' state.
Moreover, these errors may not be thrown instantly and the user may have
to wait before actually knowing that something is off.

Add steps to validate the target IC network and the target test
canister.

Network validation checks the following:
1) All "backend" NNS canisters are installed.
2) The network has SNS subnet.
3) The SNS WASM canister has SNS canisters' WASM modules.

Test canister validation checks the following:
1) Canister was created and installed.
2) The NNS Root canister is controller of the canister.