### PR TITLE
sns-testing: use hardcoded treasury identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12906,6 +12906,7 @@ dependencies = [
  "ic-sns-wasm",
  "icp-ledger",
  "k256 0.13.4",
+ "lazy_static",
  "pocket-ic",
  "rand 0.8.5",
  "rand_chacha 0.3.1",

--- a/rs/sns/testing/BUILD.bazel
+++ b/rs/sns/testing/BUILD.bazel
@@ -33,6 +33,7 @@ DEPENDENCIES = [
     "@crate_index//:ic-agent",
     "@crate_index//:ic-management-canister-types",
     "@crate_index//:k256",
+    "@crate_index//:lazy_static",
     "@crate_index//:rand",
     "@crate_index//:rand_chacha",
     "@crate_index//:reqwest",

--- a/rs/sns/testing/Cargo.toml
+++ b/rs/sns/testing/Cargo.toml
@@ -47,6 +47,7 @@ ic-sns-swap = { path = "../swap" }
 ic-sns-wasm = { path = "../../nns/sns-wasm" }
 icp-ledger = { path = "../../ledger_suite/icp" }
 k256 = { workspace = true }
+lazy_static = { workspace = true }
 pocket-ic = { path = "../../../packages/pocket-ic" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/rs/sns/testing/README.md
+++ b/rs/sns/testing/README.md
@@ -2,14 +2,12 @@
 
 ## Prerequisites
 
-SNS testing CLI uses identities managed by `dfx`. Currently, the scenario requires two identities:
-the first one represents developer identity and is used to submit NNS/SNS proposals, and the second one
-that is used to distribute ICP tokens to the SNS swap participants
+SNS testing CLI uses identities managed by `dfx`. Currently, the scenario requires a single developer
+identity to submit NNS/SNS proposals.
 
-We suggest creating dedicated identities to use with this scenario:
+We suggest creating dedicated identity to use with this scenario:
 ```
 dfx identity new sns-testing --storage-mode=plaintext
-dfx identity new icp-treasury --storage-mode=plaintext
 ```
 Mind the `--storage-mode=plaintext` as it is required to have `.pem` files in the `dfx` directory on the disk.
 
@@ -24,7 +22,7 @@ To run the scenario on the local PocketIC instance:
    ```
 2) Bootstrap the NNS on the launched PocketIC instance:
    ```
-   bazel run //rs/sns/testing:cli -- nns-init --server-url "http://127.0.0.1:8888" --state-dir "$PWD/sns-testing" --dev-identity sns-testing --treasury-identity icp-treasury
+   bazel run //rs/sns/testing:cli -- nns-init --server-url "http://127.0.0.1:8888" --state-dir "$PWD/sns-testing" --dev-identity sns-testing
    ```
 3) Build and deploy `test` canister:
    ```
@@ -36,7 +34,7 @@ To run the scenario on the local PocketIC instance:
 4) Launch the basic SNS testing scenario:
    ```
    bazel run //rs/sns/testing:cli -- run-basic-scenario --network http://127.0.0.1:8080 \
-     --dev-identity sns-testing --treasury-identity icp-treasury \
+     --dev-identity sns-testing \
      --test-canister-id "$(dfx canister --network http://127.0.0.1:8080 id test)"
    ```
 

--- a/rs/sns/testing/src/main.rs
+++ b/rs/sns/testing/src/main.rs
@@ -5,18 +5,16 @@ use futures::future::join_all;
 use ic_base_types::CanisterId;
 use ic_nervous_system_agent::CallCanisters;
 use ic_nervous_system_integration_tests::pocket_ic_helpers::load_registry_mutations;
-use ic_sns_cli::utils::{dfx_interface, get_agent};
+use ic_sns_cli::utils::dfx_interface;
 use ic_sns_testing::nns_dapp::bootstrap_nns;
 use ic_sns_testing::sns::{create_sns, upgrade_sns_controlled_test_canister, TestCanisterInitArgs};
 use ic_sns_testing::utils::{
     build_ephemeral_agent, get_identity_principal, get_nns_neuron_hotkeys, validate_network,
-    validate_target_canister, NNS_NEURON_ID,
+    validate_target_canister, NNS_NEURON_ID, SWAP_PARTICIPANT_SECRET_KEYS, TREASURY_PRINCIPAL_ID,
+    TREASURY_SECRET_KEY,
 };
 use icp_ledger::Tokens;
-use k256::elliptic_curve::SecretKey;
 use pocket_ic::PocketIcBuilder;
-use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
 use reqwest::Url;
 
 #[derive(Debug, Parser)]
@@ -38,8 +36,6 @@ struct RunBasicScenarioOpts {
     #[arg(long)]
     dev_identity: String,
     #[arg(long)]
-    treasury_identity: String,
-    #[arg(long)]
     test_canister_id: CanisterId,
 }
 
@@ -51,8 +47,6 @@ struct NnsInitOpts {
     state_dir: PathBuf,
     #[arg(long)]
     dev_identity: String,
-    #[arg(long)]
-    treasury_identity: String,
 }
 
 async fn nns_init(opts: NnsInitOpts) {
@@ -71,14 +65,13 @@ async fn nns_init(opts: NnsInitOpts) {
     let registry_proto_path = opts.state_dir.join("registry.proto");
     let initial_mutations = load_registry_mutations(registry_proto_path);
     let dev_principal_id = get_identity_principal(&opts.dev_identity).unwrap();
-    let treasury_principal_id = get_identity_principal(&opts.treasury_identity).unwrap();
 
     bootstrap_nns(
         &pocket_ic,
         vec![initial_mutations],
         vec![
             (
-                treasury_principal_id.into(),
+                (*TREASURY_PRINCIPAL_ID).into(),
                 Tokens::from_tokens(10_000_000).unwrap(),
             ),
             (dev_principal_id.into(), Tokens::from_tokens(100).unwrap()),
@@ -96,8 +89,7 @@ async fn run_basic_scenario(opts: RunBasicScenarioOpts) {
     let network = dfx_interface.network_descriptor();
 
     let dev_agent = dfx_interface.agent();
-
-    let treasury_agent = &get_agent(&opts.network, Some(opts.treasury_identity))
+    let treasury_agent = &build_ephemeral_agent(TREASURY_SECRET_KEY.clone(), &network.clone())
         .await
         .unwrap();
 
@@ -136,12 +128,9 @@ async fn run_basic_scenario(opts: RunBasicScenarioOpts) {
         }
     }
 
-    let seed = 322_u64;
-    let mut rng = ChaChaRng::seed_from_u64(seed);
-
-    let swap_participants_keys = (0..20).map(|_r| SecretKey::random(&mut rng));
     let swap_participants_agents = join_all(
-        swap_participants_keys
+        SWAP_PARTICIPANT_SECRET_KEYS
+            .clone()
             .map(|k| async { build_ephemeral_agent(k, &network.clone()).await.unwrap() }),
     )
     .await;

--- a/rs/sns/testing/tests/sns_testing_ci.rs
+++ b/rs/sns/testing/tests/sns_testing_ci.rs
@@ -13,7 +13,7 @@ use ic_sns_testing::sns::{
 };
 use ic_sns_testing::utils::{
     validate_network, validate_target_canister, SnsTestingCanisterValidationError,
-    SnsTestingNetworkValidationError,
+    SnsTestingNetworkValidationError, TREASURY_PRINCIPAL_ID,
 };
 use icp_ledger::Tokens;
 use pocket_ic::PocketIcBuilder;
@@ -36,7 +36,7 @@ async fn test_sns_testing_basic_scenario() {
     let registry_proto_path = state_dir.join("registry.proto");
     let initial_mutations = load_registry_mutations(registry_proto_path);
     let dev_participant_id = PrincipalId::new_user_test_id(1000);
-    let treasury_principal_id = PrincipalId::new_user_test_id(322);
+    let treasury_principal_id = *TREASURY_PRINCIPAL_ID;
 
     // Installing NNS canisters
     bootstrap_nns(


### PR DESCRIPTION
Using user-provided identity as ICP treasury is error-prone since the user may accidentally provide wrong identity name as an argument.

Use hardcoded identity instead. Since it's deterministically generated, it's guaranteed to always be the same over 'sns-testing' invocations.