### PR TITLE
sns-testing: add sns-proposal-upvote subcommand

### DIFF
--- a/rs/nervous_system/agent/src/sns/governance.rs
+++ b/rs/nervous_system/agent/src/sns/governance.rs
@@ -2,7 +2,8 @@ use crate::{null_request::NullRequest, CallCanisters};
 use ic_base_types::PrincipalId;
 use ic_sns_governance_api::pb::v1::{
     governance::Version,
-    manage_neuron, manage_neuron_response,
+    manage_neuron::{self, RegisterVote},
+    manage_neuron_response,
     topics::{ListTopicsRequest, ListTopicsResponse},
     AdvanceTargetVersionRequest, AdvanceTargetVersionResponse, GetMetadataRequest,
     GetMetadataResponse, GetMode, GetModeResponse, GetNeuron, GetNeuronResponse, GetProposal,
@@ -139,6 +140,24 @@ impl GovernanceCanister {
             )),
         });
         self.manage_neuron(agent, neuron_id, request).await
+    }
+
+    pub async fn register_vote<C: CallCanisters>(
+        &self,
+        agent: &C,
+        neuron_id: NeuronId,
+        proposal: ProposalId,
+        vote: i32,
+    ) -> Result<ManageNeuronResponse, C::Error> {
+        self.manage_neuron(
+            agent,
+            neuron_id,
+            manage_neuron::Command::RegisterVote(RegisterVote {
+                proposal: Some(proposal),
+                vote,
+            }),
+        )
+        .await
     }
 
     pub async fn get_proposal<C: CallCanisters>(

--- a/rs/sns/testing/src/lib.rs
+++ b/rs/sns/testing/src/lib.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{ArgGroup, Parser};
+use clap::{ArgAction, ArgGroup, Parser};
 use ic_base_types::{CanisterId, PrincipalId};
 use ic_sns_cli::neuron_id_to_candid_subaccount::ParsedSnsNeuron;
 use url::Url;
@@ -28,6 +28,7 @@ pub enum SnsTestingSubCommand {
     RunBasicScenario(RunBasicScenarioArgs),
     /// Complete the SNS swap by providing sufficient direct participations.
     SwapComplete(SwapCompleteArgs),
+    SnsProposalUpvote(SnsProposalUpvoteArgs),
 }
 
 #[derive(Debug, Parser)]
@@ -56,6 +57,26 @@ pub struct SwapCompleteArgs {
     /// Principal ID whose neurons swap participants will follow.
     #[clap(long, group = "neuron-follow-selection")]
     pub follow_principal_neurons: Option<PrincipalId>,
+}
+
+#[derive(Debug, Parser)]
+pub struct SnsProposalUpvoteArgs {
+    /// The ID of the proposal to upvote.
+    #[arg(long)]
+    pub proposal_id: u64,
+    /// The name of the SNS to upvote the proposal in.
+    #[arg(long)]
+    pub sns_name: String,
+    /// Wait for proposal execution.
+    #[arg(
+        long,
+        action = ArgAction::Set,
+        default_value_t = false,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = false,
+    )]
+    pub wait: bool,
 }
 
 #[derive(Debug, Parser)]


### PR DESCRIPTION
Users may create SNS proposals that are not automatically accepted.

To allow simulating SNS proposal adoption, 'sns-proposal-upvote' subcommand
is added to the 'sns-testing'. This command will upvote a given SNS proposal
using the same identity neurons that were used in the 'swap-complete'
subcommand to complete the SNS swap previously.

'sns-proposal-upvote' will attempt to vote on behalf of all
'Swap.minimum_participants' deterministic identities participated in the
swap omitting those that do not have neurons that are eligible for SNS voting.