### PR TITLE
sns-testing: make used NNS neuron ID configurable

### DIFF
--- a/rs/nervous_system/agent/src/helpers/nns.rs
+++ b/rs/nervous_system/agent/src/helpers/nns.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use candid::Encode;
 use cycles_minting_canister::{NotifyMintCyclesSuccess, MEMO_MINT_CYCLES};
 use ic_base_types::PrincipalId;
 use ic_nns_common::pb::v1::{NeuronId, ProposalId};
@@ -8,7 +9,9 @@ use ic_nns_governance_api::pb::v1::{
     manage_neuron_response::Command, CreateServiceNervousSystem, MakeProposalRequest,
     ManageNeuronCommandRequest, ProposalActionRequest, ProposalInfo, Topic,
 };
+use ic_nns_governance_api::pb::v1::{ExecuteNnsFunction, NnsFunction};
 use ic_sns_wasm::pb::v1::get_deployed_sns_by_proposal_id_response::GetDeployedSnsByProposalIdResult;
+use ic_sns_wasm::pb::v1::{AddWasmRequest, SnsWasm};
 use icp_ledger::{AccountIdentifier, Subaccount, Tokens, TransferArgs};
 
 use crate::nns::governance::{get_proposal_info, manage_neuron};
@@ -155,4 +158,30 @@ pub async fn convert_icp_to_cycles<C: CallCanisters>(benecificary_agent: &C, amo
         .await
         .unwrap()
         .unwrap();
+}
+
+pub async fn add_wasm_via_nns_proposal<C: CallCanisters + ProgressNetwork>(
+    agent: &C,
+    neuron_id: NeuronId,
+    wasm: SnsWasm,
+) -> Result<ProposalInfo, String> {
+    let hash = wasm.sha256_hash();
+    let canister_type = wasm.canister_type;
+    let payload = AddWasmRequest {
+        hash: hash.to_vec(),
+        wasm: Some(wasm),
+    };
+
+    let proposal = MakeProposalRequest {
+        title: Some(format!("Add WASM for SNS canister type {}", canister_type)),
+        summary: "summary".to_string(),
+        url: "".to_string(),
+        action: Some(ProposalActionRequest::ExecuteNnsFunction(
+            ExecuteNnsFunction {
+                nns_function: NnsFunction::AddSnsWasm as i32,
+                payload: Encode!(&payload).expect("Error encoding proposal payload"),
+            },
+        )),
+    };
+    propose_and_wait(agent, neuron_id, proposal).await
 }

--- a/rs/sns/testing/README.md
+++ b/rs/sns/testing/README.md
@@ -33,7 +33,7 @@ To run the scenario on the local PocketIC instance:
    ```
 2) Bootstrap the NNS on the launched PocketIC instance:
    ```
-   bazel run //rs/sns/testing:sns-testing-init -- --server-url "http://127.0.0.1:8888" --state-dir "$PWD/sns-testing" --dev-identity sns-testing
+   bazel run //rs/sns/testing:sns-testing-init -- --server-url "http://127.0.0.1:8888" --state-dir "$PWD/sns-testing" --dev-identity sns-testing --deciding-nns-neuron-id 1
    ```
 3) Build and deploy `test` canister:
    ```
@@ -44,7 +44,7 @@ To run the scenario on the local PocketIC instance:
 4) Launch the basic SNS testing scenario:
    ```
    bazel run //rs/sns/testing:sns-testing -- --network http://127.0.0.1:8080 run-basic-scenario \
-      --dev-identity sns-testing \
+      --dev-identity sns-testing --nns-neuron-id 1 \
       --test-canister-id "$(dfx canister --network http://127.0.0.1:8080 id test)"
    ```
 
@@ -62,7 +62,7 @@ remove `$PWD/sns-testing` and `$PWD/.dfx` directories before doing the steps men
 
 2) Bootstrap the NNS on the launched PocketIC instance:
    ```
-   bazel run //rs/sns/testing:sns-testing-init -- --server-url "http://127.0.0.1:8888" --state-dir "$PWD/sns-testing" --dev-identity sns-testing
+   bazel run //rs/sns/testing:sns-testing-init -- --server-url "http://127.0.0.1:8888" --state-dir "$PWD/sns-testing" --dev-identity sns-testing --deciding-nns-neuron-id 1
    ```
 
 Once these steps are completed, the PocketIC will expose the IC network HTTP endpoint on "http://127.0.0.1:8080".
@@ -72,7 +72,7 @@ by `sns-testing` will be automatically accepted.
 Additionally, `nns-init` will output the ID of the NNS neuron that should be used to create NNS proposals.
 ```
 ...
-Use the following Neuron ID for further testing: 449479075714955186
+Use the following Neuron ID for further testing: 1
 ```
 
 ### Create the new SNS
@@ -110,7 +110,7 @@ The example will use `//rs/sns/testing:sns_testing_canister` canister as SNS-con
    pushd ../cli
    # //rs/sns/cli:sns doesn't support CLI-provided identities despite '--identity' option
    dfx identity use sns-testing
-   bazel run //rs/sns/cli:sns -- propose --network http://127.0.0.1:8080 --neuron-id 449479075714955186 $PWD/test_sns_init_v2.yaml
+   bazel run //rs/sns/cli:sns -- propose --network http://127.0.0.1:8080 --neuron-id 1 $PWD/test_sns_init_v2.yaml
    popd
    ```
 

--- a/rs/sns/testing/src/bin/init.rs
+++ b/rs/sns/testing/src/bin/init.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use ic_nervous_system_integration_tests::pocket_ic_helpers::load_registry_mutations;
+use ic_nns_common::pb::v1::NeuronId;
 use ic_sns_testing::nns_dapp::bootstrap_nns;
 use ic_sns_testing::utils::{get_identity_principal, NNS_NEURON_ID, TREASURY_PRINCIPAL_ID};
 use ic_sns_testing::NnsInitArgs;
@@ -29,6 +30,11 @@ async fn nns_init(args: NnsInitArgs) {
         *TREASURY_PRINCIPAL_ID
     };
 
+    let deciding_nns_neuron_id = args
+        .deciding_nns_neuron_id
+        .map(|id| NeuronId { id })
+        .unwrap_or(NNS_NEURON_ID);
+
     bootstrap_nns(
         &pocket_ic,
         vec![initial_mutations],
@@ -39,13 +45,14 @@ async fn nns_init(args: NnsInitArgs) {
             ),
             (dev_principal_id.into(), Tokens::from_tokens(100).unwrap()),
         ],
-        vec![dev_principal_id],
+        dev_principal_id,
+        deciding_nns_neuron_id,
     )
     .await;
     println!("NNS initialized");
     println!(
         "Use the following Neuron ID for further testing: {}",
-        NNS_NEURON_ID.id
+        deciding_nns_neuron_id.id
     );
 }
 

--- a/rs/sns/testing/src/lib.rs
+++ b/rs/sns/testing/src/lib.rs
@@ -48,6 +48,10 @@ pub struct RunBasicScenarioArgs {
     /// The ID of the canister to be controlled by the SNS created in the scenario.
     #[arg(long)]
     pub test_canister_id: CanisterId,
+    /// The NNS Neuron ID that will be used to submit the proposal to create the new SNS.
+    /// Defaults to '1'.
+    #[arg(long)]
+    pub nns_neuron_id: Option<u64>,
 }
 
 #[derive(Debug, Parser)]
@@ -238,4 +242,8 @@ pub struct NnsInitArgs {
     /// If not provided, the ephemeral identity with hardcoded principal will be used.
     #[arg(long)]
     pub icp_treasury_identity: Option<String>,
+    /// The NNS Neuron ID that will have the majority voting power in the created NNS.
+    /// Defaults to '1'.
+    #[arg(long)]
+    pub deciding_nns_neuron_id: Option<u64>,
 }

--- a/rs/sns/testing/src/nns_dapp.rs
+++ b/rs/sns/testing/src/nns_dapp.rs
@@ -1,15 +1,19 @@
+use std::time::SystemTime;
+
 use candid::{CandidType, Encode};
 use canister_test::Wasm;
 use futures::future::join_all;
 use ic_base_types::PrincipalId;
 use ic_nervous_system_integration_tests::pocket_ic_helpers::{
-    add_wasms_to_sns_wasm, install_canister_with_controllers, NnsInstaller,
+    install_canister_with_controllers, NnsInstaller, SnsWasmCanistersInstaller,
 };
+use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_constants::{
     CYCLES_MINTING_CANISTER_ID, GOVERNANCE_CANISTER_ID, IDENTITY_CANISTER_ID, LEDGER_CANISTER_ID,
     LEDGER_INDEX_CANISTER_ID, NNS_UI_CANISTER_ID, ROOT_CANISTER_ID, SNS_AGGREGATOR_CANISTER_ID,
     SNS_WASM_CANISTER_ID,
 };
+use ic_nns_governance_api::pb::v1::{neuron::DissolveState, Neuron};
 use ic_registry_transport::pb::v1::RegistryAtomicMutateRequest;
 use icp_ledger::{AccountIdentifier, Tokens};
 use pocket_ic::nonblocking::PocketIc;
@@ -29,7 +33,8 @@ pub async fn bootstrap_nns(
     pocket_ic: &PocketIc,
     initial_mutations: Vec<RegistryAtomicMutateRequest>,
     ledger_balances: Vec<(AccountIdentifier, Tokens)>,
-    neuron_hotkeys: Vec<PrincipalId>,
+    neuron_controller: PrincipalId,
+    deciding_neuron_id: NeuronId,
 ) {
     // Ensure that all required subnets are present before proceeding to install NNS canisters
     // At the moment this check doesn't make a lot of sense since we are always creating the new PocketIC instance
@@ -45,9 +50,30 @@ pub async fn bootstrap_nns(
     .await;
 
     if !canisters_installed.iter().any(|installed| *installed) {
-        // TODO @rvem: at some point in the future we might want to use
-        // non-default 'neurons_fund_hotkeys' to provide
-        // neuron hotkeys for user-provided identities.
+        const TWELVE_MONTHS_SECONDS: u64 = 30 * 12 * 24 * 60 * 60;
+
+        let voting_power_refreshed_timestamp_seconds = Some(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        );
+
+        let deciding_neuron = Neuron {
+            id: Some(deciding_neuron_id),
+            account: [0u8; 32].to_vec(),
+            controller: Some(neuron_controller),
+            cached_neuron_stake_e8s: 1_000_000_000,
+            maturity_e8s_equivalent: 1_500_000 * 1_00000000,
+            auto_stake_maturity: Some(true),
+            joined_community_fund_timestamp_seconds: Some(1),
+            dissolve_state: Some(DissolveState::DissolveDelaySeconds(TWELVE_MONTHS_SECONDS)),
+            not_for_profit: true,
+            hot_keys: vec![],
+            voting_power_refreshed_timestamp_seconds,
+            ..Default::default()
+        };
+
         let mut nns_installer = NnsInstaller::default();
         nns_installer.with_current_nns_canister_versions();
         nns_installer.with_test_governance_canister();
@@ -56,9 +82,14 @@ pub async fn bootstrap_nns(
         nns_installer.with_index_canister();
         nns_installer.with_custom_registry_mutations(initial_mutations);
         nns_installer.with_ledger_balances(ledger_balances);
-        nns_installer.with_neurons_fund_hotkeys(neuron_hotkeys);
+        nns_installer.with_neurons(vec![deciding_neuron]);
         nns_installer.install(pocket_ic).await;
-        add_wasms_to_sns_wasm(pocket_ic, false).await.unwrap();
+        SnsWasmCanistersInstaller::default()
+            .with_current_sns_canister_versions()
+            .with_nns_neuron(deciding_neuron_id, neuron_controller)
+            .add_wasms_to_sns_wasm(pocket_ic)
+            .await
+            .unwrap();
     } else if !canisters_installed.iter().all(|exists| *exists) {
         panic!("Some NNS canisters are missing, we cannot fix this automatically at the moment");
     }

--- a/rs/sns/testing/src/sns.rs
+++ b/rs/sns/testing/src/sns.rs
@@ -571,11 +571,10 @@ pub mod pocket_ic {
     use ic_nervous_system_integration_tests::pocket_ic_helpers::{
         install_canister_on_subnet, nns::ledger::mint_icp,
     };
+    use ic_nns_common::pb::v1::NeuronId;
     use ic_nns_constants::ROOT_CANISTER_ID;
     use ic_sns_governance_api::pb::v1::ProposalId;
     use icp_ledger::{Tokens, DEFAULT_TRANSFER_FEE};
-
-    use crate::utils::NNS_NEURON_ID;
 
     pub async fn install_test_canister(
         pocket_ic: &PocketIc,
@@ -604,6 +603,7 @@ pub mod pocket_ic {
     pub async fn create_sns(
         pocket_ic: &PocketIc,
         dev_participant_id: PrincipalId,
+        dev_neuron_id: NeuronId,
         dapp_canister_ids: Vec<CanisterId>,
         follow_dev_neuron: bool,
     ) -> Sns {
@@ -611,7 +611,7 @@ pub mod pocket_ic {
 
         super::create_sns(
             &dev_participant,
-            NNS_NEURON_ID,
+            dev_neuron_id,
             &dev_participant,
             dapp_canister_ids,
             follow_dev_neuron,

--- a/rs/sns/testing/tests/sns_testing_ci.rs
+++ b/rs/sns/testing/tests/sns_testing_ci.rs
@@ -8,6 +8,7 @@ use ic_nervous_system_agent::pocketic_impl::PocketIcAgent;
 use ic_nervous_system_integration_tests::pocket_ic_helpers::{
     install_canister_on_subnet, load_registry_mutations, NnsInstaller, STARTING_CYCLES_PER_CANISTER,
 };
+use ic_nns_common::pb::v1::NeuronId;
 use ic_nns_constants::{LEDGER_INDEX_CANISTER_ID, ROOT_CANISTER_ID};
 use ic_sns_testing::nns_dapp::bootstrap_nns;
 use ic_sns_testing::sns::sns_proposal_upvote;
@@ -28,8 +29,9 @@ use pocket_ic::PocketIcBuilder;
 use tempfile::TempDir;
 
 const DEV_PARTICIPANT_ID: PrincipalId = PrincipalId::new_user_test_id(1000);
+const DEV_NEURON_ID: NeuronId = NeuronId { id: 1000u64 };
 
-async fn prepare_network_for_test(dev_participant_id: PrincipalId, state_dir: PathBuf) -> PocketIc {
+async fn prepare_network_for_test(dev_participant_id: PrincipalId, dev_neuron_id: NeuronId, state_dir: PathBuf) -> PocketIc {
     // Preparing the PocketIC-based network
 
     let pocket_ic = PocketIcBuilder::new()
@@ -52,7 +54,8 @@ async fn prepare_network_for_test(dev_participant_id: PrincipalId, state_dir: Pa
             treasury_principal_id.into(),
             Tokens::from_tokens(10_000_000).unwrap(),
         )],
-        vec![dev_participant_id],
+        dev_participant_id,
+        dev_neuron_id,
     )
     .await;
     assert!(validate_network(&pocket_ic).await.is_empty());
@@ -99,13 +102,21 @@ async fn test_sns_testing_basic_scenario_with_sns_neuron_following() {
     let state_dir = state_dir.path().to_path_buf();
 
     let dev_participant_id = DEV_PARTICIPANT_ID;
+    let dev_neuron_id = DEV_NEURON_ID;
 
-    let pocket_ic = prepare_network_for_test(dev_participant_id, state_dir).await;
+    let pocket_ic = prepare_network_for_test(dev_participant_id, dev_neuron_id, state_dir).await;
 
     let test_canister_id = prepare_test_canister(&pocket_ic).await;
 
     // Creating an SNS
-    let sns = create_sns(&pocket_ic, dev_participant_id, vec![test_canister_id], true).await;
+    let sns = create_sns(
+        &pocket_ic,
+        dev_participant_id,
+        dev_neuron_id,
+        vec![test_canister_id],
+        true,
+    )
+    .await;
     let new_greeting = "Hi".to_string();
     // Upgrading the test canister via SNS voting
     let proposal_id = propose_sns_controlled_test_canister_upgrade(
@@ -129,8 +140,9 @@ async fn test_sns_testing_basic_scenario_without_sns_neuron_following() {
     let state_dir = state_dir.path().to_path_buf();
 
     let dev_participant_id = DEV_PARTICIPANT_ID;
+    let dev_neuron_id = DEV_NEURON_ID;
 
-    let pocket_ic = prepare_network_for_test(dev_participant_id, state_dir).await;
+    let pocket_ic = prepare_network_for_test(dev_participant_id, dev_neuron_id, state_dir).await;
 
     let test_canister_id = prepare_test_canister(&pocket_ic).await;
 
@@ -138,6 +150,7 @@ async fn test_sns_testing_basic_scenario_without_sns_neuron_following() {
     let sns = create_sns(
         &pocket_ic,
         dev_participant_id,
+        dev_neuron_id,
         vec![test_canister_id],
         false,
     )
@@ -173,6 +186,8 @@ async fn test_sns_testing_basic_scenario_without_sns_neuron_following() {
 
 #[tokio::test]
 pub async fn test_missing_nns_canisters() {
+    let dev_participant_id = PrincipalId::new_user_test_id(1000);
+    let dev_neuron_id = NeuronId { id: 1000u64 };
     // Preparing the PocketIC-based network
     let pocket_ic = PocketIcBuilder::new()
         .with_nns_subnet()
@@ -182,7 +197,14 @@ pub async fn test_missing_nns_canisters() {
         .build_async()
         .await;
     // Installing NNS canisters
-    bootstrap_nns(&pocket_ic, vec![], vec![], vec![]).await;
+    bootstrap_nns(
+        &pocket_ic,
+        vec![],
+        vec![],
+        dev_participant_id,
+        dev_neuron_id,
+    )
+    .await;
 
     // Deleting the ledger-index canister
     pocket_ic


### PR DESCRIPTION
Currently the ID of the NNS neuron that is used to submit proposals is hardcoded which is potentially error-prone.

To fix this, 'sns-testing-init' and 'sns-testing run-basic scenario' were made to consider neuron ID instead of using the hardcoded ID from a separate crate.